### PR TITLE
Supporting custom boostrapping assembly

### DIFF
--- a/AutofacOnFunctions/Services/Ioc/BootstrapperCollector.cs
+++ b/AutofacOnFunctions/Services/Ioc/BootstrapperCollector.cs
@@ -17,5 +17,13 @@ namespace AutofacOnFunctions.Services.Ioc
                 .SelectMany(x => x.GetTypes())
                 .Where(x => typeof(IBootstrapper).IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract).ToList();
         }
+
+        public List<Type> GetBootstrappers(string bootstrappingAssembly)
+        {   
+            return AppDomain.CurrentDomain.GetAssemblies()
+                .Where(x => x.GetName().Name.StartsWith(bootstrappingAssembly))
+                .SelectMany(x => x.GetTypes())
+                .Where(x => typeof(IBootstrapper).IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract).ToList();
+        }
     }
 }

--- a/AutofacOnFunctions/Services/Ioc/ContainerInitializer.cs
+++ b/AutofacOnFunctions/Services/Ioc/ContainerInitializer.cs
@@ -8,6 +8,12 @@ namespace AutofacOnFunctions.Services.Ioc
     {
         private readonly ILoggerFactory _loggerFactory;
         private IContainer _container;
+        private string _bootstrappingAssembly = null;
+
+        public void SetBoostrappingAssembly(string bootstrappingAssembly)
+        {
+            _bootstrappingAssembly = bootstrappingAssembly;
+        }
 
         public ContainerInitializer(ILoggerFactory loggerFactory)
         {
@@ -26,7 +32,7 @@ namespace AutofacOnFunctions.Services.Ioc
 
         private void InitializeContainer()
         {
-            var moduleCollector = new ModuleCollector();
+            var moduleCollector = new ModuleCollector(_bootstrappingAssembly);
             var containerBuilder = new ContainerBuilder();
             var modules = moduleCollector.Collect();
             RegisterModules(modules, containerBuilder);

--- a/AutofacOnFunctions/Services/Ioc/InjectAttribute.cs
+++ b/AutofacOnFunctions/Services/Ioc/InjectAttribute.cs
@@ -10,13 +10,22 @@ namespace AutofacOnFunctions.Services.Ioc
         public string Name { get; set; }
         public bool HasName => !string.IsNullOrWhiteSpace(Name);
 
-        public InjectAttribute()
-        {
+        public string BootstrappingAssembly { get; set; }
+        public bool HasBootstrappingAssembly => !string.IsNullOrWhiteSpace(BootstrappingAssembly);
 
-        }
-        public InjectAttribute(string name)
+        public InjectAttribute() { }
+
+        public InjectAttribute(string name, string bootstrappingAssembly = "")
         {
             Name = name;
+            BootstrappingAssembly = bootstrappingAssembly;
         }
+
+        public InjectAttribute(string bootstrappingAssembly, bool useBoostrappingAssembly)
+        {
+            BootstrappingAssembly = bootstrappingAssembly;
+        }
+
+        
     }
 }

--- a/AutofacOnFunctions/Services/Ioc/ModuleCollector.cs
+++ b/AutofacOnFunctions/Services/Ioc/ModuleCollector.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Autofac;
 using AutofacOnFunctions.Exceptions;
 using AutofacOnFunctions.Services.Modules;
@@ -9,21 +8,29 @@ namespace AutofacOnFunctions.Services.Ioc
 {
     public class ModuleCollector
     {
-        public List<Module> Collect()
+        private readonly string _bootstrappingAssembly;
+
+        public ModuleCollector(string bootstrappingAssembly)
         {
+            _bootstrappingAssembly = bootstrappingAssembly;
+        }
+
+        public List<Module> Collect()
+        {   
             var modules = new List<Module>
             {
                 new CommonModule(),
                 new LoggingModule()
             };
-            modules.AddRange(GetModules());
+            modules.AddRange(GetModules(_bootstrappingAssembly));
             return modules;
         }
 
-        private static List<Module> GetModules()
+        private static List<Module> GetModules(string bootstrappingAssembly)
         {
+            var isBootstrappingAssemblyPresent = !string.IsNullOrWhiteSpace(bootstrappingAssembly);
             var bootstrapperCollector = new BootstrapperCollector();
-            var bootstrappers = bootstrapperCollector.GetBootstrappers();
+            var bootstrappers = isBootstrappingAssemblyPresent ? bootstrapperCollector.GetBootstrappers(bootstrappingAssembly) : bootstrapperCollector.GetBootstrappers();
 
             if (bootstrappers.Count == 0)
             {

--- a/AutofacOnFunctions/Services/Ioc/Provider/Binding/InjectAttributeBindingProvider.cs
+++ b/AutofacOnFunctions/Services/Ioc/Provider/Binding/InjectAttributeBindingProvider.cs
@@ -17,7 +17,7 @@ namespace AutofacOnFunctions.Services.Ioc.Provider.Binding
         }
 
         public Task<IBinding> TryCreateAsync(BindingProviderContext context)
-        {
+        {   
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
@@ -30,6 +30,8 @@ namespace AutofacOnFunctions.Services.Ioc.Provider.Binding
                 return Task.FromResult<IBinding>(null);
             }
 
+            if (injectAttribute.HasBootstrappingAssembly)
+                _containerInitializer.SetBoostrappingAssembly(injectAttribute.BootstrappingAssembly);
             var container = _containerInitializer.GetOrCreateContainer();
             var objectResolver = container.Resolve<IObjectResolver>();
             return Task.FromResult<IBinding>(new InjectAttributeBinding(parameterInfo, objectResolver));


### PR DESCRIPTION
Added option to add the name of bootstrapping assembly in the Inject Attribute.

Sample Usage
```
        [FunctionName("Function1")]
        public static async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req, [Inject("Microsoft.Test.AutofacTestFunction", true)] ITestService service)
        {   
            string serviceData = service.GetSomeString();
            return (ActionResult)new OkObjectResult($"Output - {serviceData}");
        }
```